### PR TITLE
(ci) Fix missingInclude errors for generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
             
             - name: Run static code analysis
               run: |
-                cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-supp --inconclusive --enable=all \
+                cppcheck --version
+                cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-suppr --inconclusive --enable=all \
                 -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest -I ./include \
                 ./include ./src ./tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
             
             - name: Run static code analysis
               run: |
-                cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inconclusive --enable=all \
-                -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest \
-                ./include/ ./src/ ./tests/
+                cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-supp --inconclusive --enable=all \
+                -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest -I ./include \
+                ./include ./src ./tests
 
     tests:
         name: Run tests to prevent code regression

--- a/tools/ci
+++ b/tools/ci
@@ -8,6 +8,6 @@ find ./src/ ./tests/ -type f -name "*.cpp" -print0 | xargs -0 clang-format --i -
 # Headers (*.hpp)
 find ./include/ -type f -name "*.hpp" -print0 | xargs -0 clang-format --i --style=file
 
-cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inconclusive --enable=all \
-    -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest \
-    ./include/ ./src/ ./tests/
+cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-supp --inconclusive --enable=all \
+    -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest -I ./include \
+    ./include ./src ./tests

--- a/tools/ci
+++ b/tools/ci
@@ -8,6 +8,6 @@ find ./src/ ./tests/ -type f -name "*.cpp" -print0 | xargs -0 clang-format --i -
 # Headers (*.hpp)
 find ./include/ -type f -name "*.hpp" -print0 | xargs -0 clang-format --i --style=file
 
-cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-supp --inconclusive --enable=all \
+cppcheck --error-exitcode=1 --std=c++17 --language=c++ --suppress=missingIncludeSystem --inline-suppr --inconclusive --enable=all \
     -I /usr/include/opencv4 -I /usr/include/x86_64-linux-gnu/qt6 -I /usr/include/gtest -I ./include \
     ./include ./src ./tests


### PR DESCRIPTION
- Fix the error in the CI workflow, during the static analysis of the code, when Cppcheck was raising an error each time a generated file was included
- Now to include a generated file the comment: // cppcheck-suppress missingInclude must be placed a line before